### PR TITLE
Add basic password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+gem 'fog-aws'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,12 +69,31 @@ GEM
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     erubis (2.7.0)
+    excon (0.62.0)
     execjs (2.7.0)
     ffi (1.10.0)
+    fog-aws (3.3.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
+    ipaddress (0.8.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -92,6 +111,9 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -194,6 +216,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   coffee-rails (~> 4.2)
+  fog-aws
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   protect_from_forgery with: :exception
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == 'admin' && password == '2222'
+    end
+  end
 end


### PR DESCRIPTION
#WHAT
Basic認証の実装

#WHY
ユーザーが本物のメルカリと自分たちのコピーサイトとを間違えないようにするためにコピーサイトに入るための認証を設定した。
目的が限られているので、環境変数でのパスワードの設定は行っていない。よってコード上にパスワードが記述されている。